### PR TITLE
Added customFields field to Identified and custom_fields annotation

### DIFF
--- a/src/main/java/org/atlasapi/deer/client/uri/Annotation.java
+++ b/src/main/java/org/atlasapi/deer/client/uri/Annotation.java
@@ -30,7 +30,8 @@ public enum Annotation {
     CONTENT_DETAIL,
     TAGS,
     MODIFIED_DATES,
-    LOCATIONS
+    LOCATIONS,
+    CUSTOM_FIELDS,
     ;
 
     private static final BiMap<String, Annotation> LOOKUP =


### PR DESCRIPTION
The field is intended to be used for arbitrary data
that does not fit within the confines of the regular
atlas model e.g. additional title fields or customer-specific
fields.